### PR TITLE
tw-29333400 | Add ClamAV to Drupal Starter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "drupal/better_exposed_filters": "*",
         "drupal/block_class": "*",
         "drupal/block_field": "*",
+        "drupal/clamav": "*",
         "drupal/config_filter": "*",
         "drupal/config_ignore": "*",
         "drupal/config_split": "*",

--- a/recipe.yml
+++ b/recipe.yml
@@ -50,6 +50,7 @@ install:
   - block_class
   - block_field
   - checklistapi
+  - clamav
   - critical_css
   - crop
   - csp
@@ -147,6 +148,7 @@ config:
     # Contrib.
     access_unpublished: '*'
     block_class: '*'
+    clamav: '*'
     crop: '*'
     diff: '*'
     easy_breadcrumb: '*'


### PR DESCRIPTION
## Description
> Add ClamAV to the drupal builder starter


## Related Tickets

* [Add ClamAV to Drupal Starter](https://kanopi.teamwork.com/app/tasks/29333400)


## Deploy Notes

_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc._
